### PR TITLE
Fix temporarily: resolve stock duplications on adding warestock.

### DIFF
--- a/api/models/Cluster/Stocks/StockWarehouse.js
+++ b/api/models/Cluster/Stocks/StockWarehouse.js
@@ -233,7 +233,8 @@ function getStockReportLocations( stockwarehouse, reports, target_locations, cb 
 				.find({ organization_id: stockwarehouse.organization_id,
 										stock_warehouse_id: target_location.id,
 										report_month: report.report_month,
-										report_year: report.report_year })
+                    report_year: report.report_year,
+                    report_id: { '!' : null } })
 				.populateAll()
 				.exec(function(err, stocklocation){
 


### PR DESCRIPTION
Could be used temporarily to resolve stock duplication till global fix. By omitting stocklocations with null report_id fields.