### PR TITLE
bugfix: locations no update on user update

### DIFF
--- a/api/controllers/Cluster/ProjectController.js
+++ b/api/controllers/Cluster/ProjectController.js
@@ -272,9 +272,9 @@ module.exports = {
         Project.update( { id: $project.id }, updatedRelationsUser ),
         BudgetProgress.update( findProject, updatedRelationsUser ),
         TargetBeneficiaries.update( findProject, updatedRelationsUser ),
-        TargetLocation.update( findProject, updatedRelationsUser ),
+        //TargetLocation.update( findProject, updatedRelationsUser ),
         Report.update( findProject, updatedRelationsUser ),
-        Location.update( findProject, updatedRelationsUser ),
+        //Location.update( findProject, updatedRelationsUser ),
         Beneficiaries.update( findProject, updatedRelationsUser ),
       ])
         .catch( function(err) {


### PR DESCRIPTION
on project user update, to keep consistency within a project, related collection to project were updated, including for target locations and location,
as there is per target location reporting, it is not needed for these ones.