### PR TITLE
update: project reports start date

### DIFF
--- a/api/models/Cluster/Project/Project.js
+++ b/api/models/Cluster/Project/Project.js
@@ -337,7 +337,7 @@ function getProjectReports( project ) {
 	// dates
 	var project_start = moment( project.project_start_date ).startOf( 'M' ),
 			project_end = moment( project.project_end_date ).endOf( 'M' ),
-			reports_start = moment( '2017-01-01' ),
+			reports_start = moment(project.project_start_date).startOf('Y')>=moment('2017-01-01')?moment(project.project_start_date).startOf('Y'):moment('2017-01-01'),
 			reports_end = moment().endOf( 'M' );
 
 	// variables


### PR DESCRIPTION
new year reports with start date over 2018 not created with reports entries for 2017