### PR TITLE
Fix locations status for notifications

### DIFF
--- a/api/controllers/Cluster/Reports/ReportController.js
+++ b/api/controllers/Cluster/Reports/ReportController.js
@@ -546,6 +546,9 @@ module.exports = {
         // for each location
         $report.locations.forEach( function( location, i ){
 
+          Location.update({id: location.id}, { report_status: location.report_status }).exec( function( err, update ){
+
+          if (err) return res.negotiate( err );
           // beneficiaries
           Beneficiaries
             .updateOrCreateEach( { location_id: location.id }, location.beneficiaries, function( err, beneficiaries ){
@@ -632,7 +635,7 @@ module.exports = {
               }
 
           });
-
+        });
         });
 
     });

--- a/api/controllers/Cluster/Reports/ReportTasksController.js
+++ b/api/controllers/Cluster/Reports/ReportTasksController.js
@@ -399,6 +399,7 @@ module.exports = {
     Report
     .find()
     .where( { project_id: { '!' : null } } )
+    .where( { report_year: moment().subtract( 1, 'M' ).year() })
     .where( { report_month: { '<=': moment().subtract( 1, 'M' ).month() } } )
     .where( { report_active: true } )
     .where( { report_status: 'todo' } )
@@ -411,6 +412,7 @@ module.exports = {
       Location
         .find()
         .where( { report_id: { '!' : null } } )
+        .where( { report_year: moment().subtract( 1, 'M' ).year() })
         .where( { report_month: { '<=': moment().subtract( 1, 'M' ).month() } } )
         .where( { report_active: true } )
         .where( { report_status: 'todo' } )


### PR DESCRIPTION
https://github.com/pfitzpaddy/ngm-reportDesk/issues/47
- fix when Location report_status wasn't changed on Report report_status change (e.g. to 'complete'
- added filtering by year for notification reminder so that only current reporting year notifications sent


to update db so that locations statuses match report one
runs a couple of minutes on test machine

```javascript
db.report.find({report_status:'complete'}).forEach(function(r){
  db.location.find({report_id: r._id.valueOf() }).forEach(function(l){
    if (l.report_status && l.report_status !== 'complete'){
      l.report_status = 'complete';
      db.getCollection('location').save( l );
    }
  })
})

````