### PR TITLE
feature: admin/5w protection cpie activity filtering

### DIFF
--- a/api/controllers/Cluster/Dashboards/AdminDashboardController.js
+++ b/api/controllers/Cluster/Dashboards/AdminDashboardController.js
@@ -23,8 +23,8 @@ var AdminDashboardController = {
   getClusterAdminIndicator: function( req, res ){
 
     // request input
-    if ( !req.param( 'report_type' ) || !req.param( 'indicator' ) || !req.param( 'cluster_id' ) || !req.param( 'organization_tag' ) || !req.param( 'adminRpcode' )  || !req.param( 'admin0pcode' ) || !req.param( 'start_date' ) || !req.param( 'end_date' ) ) {
-      return res.json( 401, { err: 'report_type, indicator, cluster_id, adminRpcode, admin0pcode, start_date, end_date required!' });
+    if ( !req.param( 'report_type' ) || !req.param( 'indicator' ) || !req.param( 'cluster_id' ) || !req.param( 'organization_tag' ) || !req.param( 'activity_type_id' ) || !req.param( 'adminRpcode' )  || !req.param( 'admin0pcode' ) || !req.param( 'start_date' ) || !req.param( 'end_date' ) ) {
+      return res.json( 401, { err: 'report_type, indicator, cluster_id, organization_tag, activity_type_id, adminRpcode, admin0pcode, start_date, end_date required!' });
     }
 
     // organizations to exclude totally
@@ -37,6 +37,7 @@ var AdminDashboardController = {
           list: req.param( 'list' ),
           indicator: req.param( 'indicator' ),
           report_type: req.param( 'report_type' ),
+          activity_type_id: req.param( 'activity_type_id' ) === 'all'? {} : { 'activity_type.activity_type_id': req.param( 'activity_type_id' ) },
           organization_tag: req.param( 'organization_tag' ),
           cluster_filter: req.param( 'cluster_id' ) === 'all' || req.param( 'cluster_id' ) === 'acbar' ? {} : { cluster_id: req.param( 'cluster_id' ) },
           acbar_partners_filter: req.param( 'cluster_id' ) === 'acbar' ? { project_acbar_partner: true } : {},
@@ -504,6 +505,7 @@ var AdminDashboardController = {
           .where( params.acbar_partners_filter )
           .where( params.adminRpcode_filter )
           .where( params.admin0pcode_filter )
+          .where( params.activity_type_id )
           .where( { project_start_date: { '<=': new Date( params.end_date ) } } )
           .where( { project_end_date: { '>=': new Date( params.start_date ) } } )
           .where( params.organization_filter )
@@ -533,6 +535,7 @@ var AdminDashboardController = {
             .where( params.acbar_partners_filter )
             .where( params.adminRpcode_filter )
             .where( params.admin0pcode_filter )
+            .where( params.activity_type_id )
             .where( { project_start_date: { '<=': new Date( params.end_date ) } } )
             .where( { project_end_date: { '>=': new Date( params.start_date ) } } )
             .where( params.organization_filter )
@@ -605,6 +608,7 @@ var AdminDashboardController = {
           .where( params.adminRpcode_filter )
           .where( params.admin0pcode_filter )
           .where( { report_active: true } )
+          .where( params.activity_type_id )
           .where( { report_status: [ 'todo', 'complete' ] } )
           .where( { reporting_period: { '>=': params.moment( params.start_date ).format('YYYY-MM-DD'), '<=': params.moment( params.end_date ).format('YYYY-MM-DD') } } )
           .where( params.organization_filter )
@@ -673,6 +677,7 @@ var AdminDashboardController = {
           .where( params.adminRpcode_filter )
           .where( params.admin0pcode_filter )
           .where( { report_active: true } )
+          .where( params.activity_type_id )
           .where( { report_status: 'todo' } )
           .where( { reporting_period: { '>=': params.moment( params.start_date ).format('YYYY-MM-DD'), '<=': params.moment( params.end_date ).format('YYYY-MM-DD') } } )
           .where( params.organization_filter )
@@ -776,6 +781,7 @@ var AdminDashboardController = {
           .where( params.adminRpcode_filter )
           .where( params.admin0pcode_filter )
           .where( { report_active: true } )
+          .where( params.activity_type_id )
           .where( { report_status: 'complete' } )
           .where( { reporting_period: { '>=': params.moment( params.start_date ).format('YYYY-MM-DD'), '<=': params.moment( params.end_date ).format('YYYY-MM-DD') } } )
           .where( params.organization_filter )
@@ -887,6 +893,7 @@ var AdminDashboardController = {
           .where( params.adminRpcode_filter )
           .where( params.admin0pcode_filter )
           .where( { report_active: true } )
+          .where( params.activity_type_id )
           .where( { reporting_period: { '>=': params.moment( params.start_date ).format('YYYY-MM-DD'), '<=': params.moment( params.end_date ).format('YYYY-MM-DD') } } )
           .where( params.organization_filter )
           .sort('updatedAt DESC')
@@ -903,6 +910,7 @@ var AdminDashboardController = {
               .where( params.adminRpcode_filter )
               .where( params.admin0pcode_filter )
               .where( { report_active: true } )
+              .where( params.activity_type_id )
               .where( { report_status: 'complete' } )
               .where( { reporting_period: { '>=': params.moment( params.start_date ).format('YYYY-MM-DD'), '<=': params.moment( params.end_date ).format('YYYY-MM-DD') } } )
               .where( params.organization_filter )
@@ -935,6 +943,7 @@ var AdminDashboardController = {
           .where( params.adminRpcode_filter )
           .where( params.admin0pcode_filter )
           .where( params.cluster_filter )
+          .where( params.activity_type_id )
           .where( params.acbar_partners_filter )
           .where( params.organization_filter )
           .where( { project_budget_date_recieved: { '>=': new Date( params.start_date ), '<=': new Date( params.end_date ) } } )

--- a/api/controllers/Cluster/Dashboards/ClusterDashboardController.js
+++ b/api/controllers/Cluster/Dashboards/ClusterDashboardController.js
@@ -47,6 +47,7 @@ var ClusterDashboardController = {
       list: req.param('list') ? req.param('list') : false,
       indicator: req.param('indicator'),
       cluster_id: req.param('cluster_id'),
+      activity_type_id: req.param( 'activity_type_id' ) ? req.param( 'activity_type_id' ) : 'all',
       adminRpcode: req.param('adminRpcode'),
       admin0pcode: req.param('admin0pcode'),
       organization_tag: req.param('organization_tag'),
@@ -69,6 +70,7 @@ var ClusterDashboardController = {
       admin1pcode: params.admin1pcode === 'all' ? {} : { admin1pcode: params.admin1pcode },
       admin2pcode: params.admin2pcode === 'all' ? {} : { admin2pcode: params.admin2pcode },
       cluster_id: params.cluster_id === 'all' || params.cluster_id === 'rnr_chapter' || params.cluster_id === 'acbar' ? {} : { or: [{ cluster_id: params.cluster_id }, { mpc_purpose_cluster_id: { contains: params.cluster_id } } ] },
+      activity_type_id: params.activity_type_id === 'all'  ? {} : { activity_type_id: params.activity_type_id },
       acbar_partners: params.cluster_id === 'acbar' ? { project_acbar_partner: true } : {},
       organization_tag: params.organization_tag === 'all' ? { organization_tag: { '!': $nin_organizations } } : { organization_tag: params.organization_tag },
       beneficiaries: params.beneficiaries[0] === 'all' ? {} : { beneficiary_type_id: params.beneficiaries },
@@ -97,6 +99,7 @@ var ClusterDashboardController = {
           .where( filters.admin1pcode )
           .where( filters.admin2pcode )
           .where( filters.cluster_id )
+          .where( filters.activity_type_id )
           .where( filters.acbar_partners )
           .where( filters.organization_tag )
           .where( filters.beneficiaries )
@@ -127,6 +130,7 @@ var ClusterDashboardController = {
           .where( filters.admin1pcode )
           .where( filters.admin2pcode )
           .where( filters.cluster_id )
+          .where( filters.activity_type_id )
           .where( filters.acbar_partners )
           .where( filters.organization_tag )
           .where( filters.beneficiaries )
@@ -194,6 +198,7 @@ var ClusterDashboardController = {
           .where( filters.admin1pcode )
           .where( filters.admin2pcode )
           .where( filters.cluster_id )
+          .where( filters.activity_type_id )
           .where( filters.acbar_partners )
           .where( filters.organization_tag )
           .where( filters.beneficiaries )
@@ -263,6 +268,7 @@ var ClusterDashboardController = {
           .where( filters.admin1pcode )
           .where( filters.admin2pcode )
           .where( filters.cluster_id )
+          .where( filters.activity_type_id )
           .where( filters.acbar_partners )
           .where( filters.organization_tag )
           .where( filters.beneficiaries )
@@ -377,6 +383,7 @@ var ClusterDashboardController = {
           .where( filters.admin1pcode )
           .where( filters.admin2pcode )
           .where( filters.cluster_id )
+          .where( filters.activity_type_id )
           .where( filters.acbar_partners )
           .where( filters.organization_tag )
           .where( filters.beneficiaries )
@@ -584,6 +591,7 @@ var ClusterDashboardController = {
           .where( filters.admin1pcode )
           .where( filters.admin2pcode )
           .where( filters.cluster_id )
+          .where( filters.activity_type_id )
           .where( filters.acbar_partners )
           .where( filters.organization_tag )
           .where( filters.beneficiaries )
@@ -1113,6 +1121,7 @@ var ClusterDashboardController = {
           .where( filters.admin1pcode )
           .where( filters.admin2pcode )
           .where( filters.cluster_id )
+          .where( filters.activity_type_id )
           .where( filters.acbar_partners )
           .where( filters.organization_tag )
           .where( filters.beneficiaries )


### PR DESCRIPTION
Adding _Activity_ filter for Protection CPiE subcluster

![activity_filter](https://user-images.githubusercontent.com/29349472/41973713-09e670ec-7a2b-11e8-8ae0-5a9650b58f53.png) ![cpie_filter](https://user-images.githubusercontent.com/29349472/41973829-63e0df10-7a2b-11e8-8308-5e5b0a61bef5.png)

So far in menu activity filter values are defined on frontend, contains only CPiE. Option only for Protection.
url update: +activity_type_id, values: 'all', 'cpie'
Admin: /cluster/admin/:adminRpcode/:admin0pcode/:cluster_id/:activity_type_id/:organization_tag/:report_type/:start/:end
5w: /cluster/5w/:adminRpcode/:admin0pcode/:admin1pcode/:admin2pcode/:cluster_id/:activity_type_id/:organization_tag/:beneficiaries/:start/:end
