### PR TITLE
fix: setReportBulk cast to date fields

### DIFF
--- a/api/models/Cluster/Report/Beneficiaries.js
+++ b/api/models/Cluster/Report/Beneficiaries.js
@@ -691,7 +691,11 @@ module.exports = {
 				if(err) return cb(err, false);
 
 				// simple association finder, check waterline valuesParser if more advanced functionality needed
-				var associationProps = Object.keys(self.attributes).filter(function(key){return self.attributes[key].hasOwnProperty("collection");});
+				var associationProps = Object.keys(self.attributes)
+											 .filter(function(key){return self.attributes[key].hasOwnProperty("collection");});
+				// date fields
+				var dateProps 		 = Object.keys(self.attributes)
+											 .filter(function(key){return self.attributes[key].type === 'date';});
 
 				var bulk = collection.initializeUnorderedBulkOp();
 				// add bulk operation per location, per beneficiary
@@ -704,6 +708,13 @@ module.exports = {
 					value.beneficiaries.forEach(function(b,j){
 						// set report status
 						b.report_status = status;
+
+						// cast date fields to date
+						dateProps.forEach(function(d){
+							if( b[d] ){
+								b[d] = new Date(b[d]);
+							}
+						});
 
 						// validate each obj with sails model
 						// if omitted will insert any incoming object into collection, but much faster

--- a/api/models/Cluster/Report/Location.js
+++ b/api/models/Cluster/Report/Location.js
@@ -471,6 +471,16 @@ module.exports = {
 					bulk.find( {_id:ObjectId(value.id)} ).updateOne({ $set: { report_status:status.report_status } });
 				} else {
 					// runs only for add new location functionality in monthly report
+
+					// date fields
+					var dateProps = Object.keys(self.attributes).filter(function(key){return self.attributes[key].type === 'date';});
+					// and cast to date
+					dateProps.forEach(function(d){
+						if( value[d] ){
+							value[d] = new Date(value[d]);
+						}
+					});
+
 					value._id = new ObjectId()
 					bulk.insert(value)
 				}			


### PR DESCRIPTION
it saves bulk date fields as ISODate in db

fix for ng 0 dashboard case, as date comparison was versus string

recently submitted beneficiaries with bulk with no cast to date require an update for these date fields, resaving report fixes the issue