### PR TITLE
update: save report add updatedAt && createdAt

### DIFF
--- a/api/models/Cluster/Report/Beneficiaries.js
+++ b/api/models/Cluster/Report/Beneficiaries.js
@@ -737,11 +737,13 @@ module.exports = {
 
 							// if id exists update or create
 							if (_b.id) {
+								b.updatedAt = _b.updatedAt = new Date();
 								bulk.find( {_id:ObjectId(_b.id)} ).updateOne({ $set: _b });
 							} else {
 								b.location_id = _b.location_id  = value.id;
 								// generate beneficiary id for associations reference
 								b._id = _b._id  = new ObjectId()
+								b.updatedAt = _b.updatedAt =  b.createdAt = _b.createdAt = new Date();
 								bulk.insert(_b)
 							}
 

--- a/api/models/Cluster/Report/Location.js
+++ b/api/models/Cluster/Report/Location.js
@@ -468,6 +468,7 @@ module.exports = {
 				// add operation per location, per beneficiary
 				value.report_status 	= status;
 				if (value.id) {
+					value.updatedAt = new Date();
 					bulk.find( {_id:ObjectId(value.id)} ).updateOne({ $set: { report_status:status.report_status } });
 				} else {
 					// runs only for add new location functionality in monthly report
@@ -480,7 +481,7 @@ module.exports = {
 							value[d] = new Date(value[d]);
 						}
 					});
-
+					value.updatedAt = value.createdAt = new Date();
 					value._id = new ObjectId()
 					bulk.insert(value)
 				}			


### PR DESCRIPTION
can omit this if no need

for missing ones get time from ObjectId 

```
db.getCollection("beneficiaries").find({createdAt: {$exists: false}}).forEach(function(doc){
  		doc.createdAt = doc._id.getTimestamp();
		db.getCollection( 'beneficiaries' ).save( doc );
});

db.getCollection("beneficiaries").find({updatedAt: {$exists: false}}).forEach(function(doc){
  		doc.updatedAt = doc._id.getTimestamp();
		db.getCollection( 'beneficiaries' ).save( doc );
});

db.getCollection("location").find({createdAt: {$exists: false}}).forEach(function(doc){
  		doc.createdAt = doc._id.getTimestamp();
		db.getCollection( 'location' ).save( doc );
});

db.getCollection("location").find({updatedAt: {$exists: false}}).forEach(function(doc){
  		doc.updatedAt = doc._id.getTimestamp();
		db.getCollection( 'location' ).save( doc );
});
```