### PR TITLE
hotfix(project): remove admins on project to not overwrite locations

### DIFF
--- a/api/controllers/Cluster/ProjectController.js
+++ b/api/controllers/Cluster/ProjectController.js
@@ -518,6 +518,9 @@ var ProjectController = {
     delete project_copy.target_locations;
     delete project_copy.createdAt;
     delete project_copy.updatedAt;
+    delete project_copy.admin1pcode;
+    delete project_copy.admin2pcode;
+    delete project_copy.admin3pcode;
 
     var project_copy_no_cluster = JSON.parse( JSON.stringify( project_copy ) );
     delete project_copy_no_cluster.cluster;


### PR DESCRIPTION
admin1,2,3 on projects would overwrite ones of target locations 
on admin1,2,3 not set already on new reports
if no need on those fields could be cleaned out from project collection:
```
db.getCollection("project").find({}).forEach(function (d) {

    if (d.admin1pcode) {
        delete d.admin1pcode
    }

    if (d.admin2pcode) {
        delete d.admin2pcode
    }

    if (d.admin3pcode) {
        delete d.admin3pcode
    }

    db.getCollection("project").save(d);

});

```