### PR TITLE
feat(report): set and notify due dates by country

### DIFF
--- a/api/controllers/Cluster/ProjectController.js
+++ b/api/controllers/Cluster/ProjectController.js
@@ -13,6 +13,8 @@ var moment = require('moment');
 var async = require('async');
 var _under = require('underscore');
 
+var REPORTING_DUE_DATE_NOTIFICATIONS_CONFIG = sails.config.REPORTING_DUE_DATE_NOTIFICATIONS_CONFIG;
+
 // project controller
 var ProjectController = {
 
@@ -31,6 +33,12 @@ var ProjectController = {
 
   // return reports for a project
   getProjectReports: function( project, cb ) {
+
+    const admin0pcode = project.admin0pcode ? project.admin0pcode : "ALL";
+    let config = REPORTING_DUE_DATE_NOTIFICATIONS_CONFIG.find(obj => obj.admin0pcode === admin0pcode);
+    if (!config) config = REPORTING_DUE_DATE_NOTIFICATIONS_CONFIG.find(obj => obj.admin0pcode === 'ALL');
+
+    const REPORTING_DUE_DATE = config.reporting_due_date;
 
     // dates
     var project_start = moment( project.project_start_date ).startOf( 'M' ),
@@ -64,7 +72,7 @@ var ProjectController = {
         report_month: moment( s_date ).add( m, 'M' ).month(),
         report_year: moment( s_date ).add( m, 'M' ).year(),
         reporting_period: moment( s_date ).add( m, 'M' ).set( 'date', 1 ).format(),
-        reporting_due_date: moment( s_date ).add( m+1, 'M' ).set( 'date', 10 ).format()
+        reporting_due_date: moment( s_date ).add( m+1, 'M' ).set( 'date', REPORTING_DUE_DATE ).format()
       };
 
       // add report with p to reports

--- a/config/notifications.js
+++ b/config/notifications.js
@@ -1,0 +1,30 @@
+// config/notifications.js
+const REPORTING_DUE_DATE_NOTIFICATIONS_CONFIG = [
+  {
+    admin0pcode: "AF",
+    soon: [8],
+    pending: [12],
+    today: [10],
+    reporting_due_date: 10
+  }, {
+    admin0pcode: "CB",
+    soon: [8],
+    pending: [12],
+    today: [10],
+    reporting_due_date: 10
+  }, {
+    admin0pcode: "ET",
+    soon: [8],
+    pending: [12],
+    today: [10],
+    reporting_due_date: 10
+  }, {
+    admin0pcode: "ALL",
+    soon: [8],
+    pending: [12],
+    today: [10],
+    reporting_due_date: 10
+  }
+]
+
+module.exports.REPORTING_DUE_DATE_NOTIFICATIONS_CONFIG = REPORTING_DUE_DATE_NOTIFICATIONS_CONFIG;


### PR DESCRIPTION
- add config by country in config/notifications  (note: not put under gitignore )
- send remind notification by countries due dates
- set reports due date on project save by country
- set reports due date on setReportsToDo on 1 of each month
based on config when ngm_reporthub_reports_reminder.sh runs setReportsReminder, reports that don't match config condition will be skipped, e.g. if fn runs on 22 Jule and in the config, there is for AF pending: [22] then AF reports due_message will be 'PENDING', and if CB today: [22] then CB reports due_message will be 'due TODAY'
```
{
    admin0pcode: "AF",
    soon: [8], // due_message = 'due SOON' [8] => 8 day of month
    pending: [12], due_message = 'PENDING' [12] => 12 day of month
    today: [10], due_message = 'due TODAY' and matches reporting_due_date [10] => 10 day of month
    reporting_due_date: 10 // matches today
}
// note: array is used so that multiple reminder dates could be set, like [6,8]
```
- send notifications for active projects only project_status : "active"

such structure is used so that in future it could be put into db, having the same stucture as other csv configs, and put on UI eventually
